### PR TITLE
Fetch rockets - Fetch data

### DIFF
--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -1,3 +1,21 @@
-const Rockets = () => <div className="profile">coming soon</div>;
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { bindActionCreators } from 'redux';
+import { loadRockets } from '../redux/rockets/rockets';
+
+const Rockets = () => {
+  const dispatch = useDispatch();
+  const loadRocketsAction = bindActionCreators(loadRockets, dispatch);
+  const rockets = useSelector((state) => state.rockets);
+
+  useEffect(() => {
+    if (rockets.length === 0) loadRocketsAction();
+    return () => null;
+  }, []);
+
+  return (
+    <div className="profile">coming soon</div>
+  );
+};
 
 export default Rockets;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -3,10 +3,12 @@ import thunk from 'redux-thunk';
 import logger from 'redux-logger';
 import dragonReducer from './dragons/dragons';
 import missionReducer from './missions/missions';
+import rocketReducer from './rockets/rockets';
 
 const reducer = combineReducers({
   dragons: dragonReducer,
   missions: missionReducer,
+  rockets: rocketReducer,
 });
 
 const store = createStore(reducer, applyMiddleware(logger, thunk));

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -1,0 +1,26 @@
+const URL = 'https://api.spacexdata.com/v3/rockets';
+
+// Actions
+const LOAD = 'spaceships/rockets/LOAD';
+
+// Reducer
+export default (state = [], action) => {
+  switch (action.type) {
+    case (LOAD):
+      return action.state;
+    default: return state;
+  }
+};
+
+// Action Creators
+export const loadRockets = () => async (dispatch) => {
+  const res = await fetch(URL);
+  const resJSON = await res.json();
+  const state = resJSON.map((rocket) => ({
+    id: rocket.rocket_id,
+    name: rocket.rocket_name,
+    description: rocket.description,
+    flickr_images: rocket.flickr_images,
+  }));
+  dispatch({ type: LOAD, state });
+};


### PR DESCRIPTION
In this milestone, the following requirements have been met:
- [x] Fetch data from the Dragons endpoint (https://api.spacexdata.com/v3/rockets) 
- [x] when a user navigates to the Rockets section.
- [x] Once the data are fetched, dispatch an action to store the selected data in Redux store:
-    id
-    rocket_name
-    Description
-    flickr_images

_NOTE: The actions are dispatched only once, not on every re-render._