### PR TITLE
Implement rocket booking cancelation - Actions

### DIFF
--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -3,12 +3,13 @@ import { useEffect } from 'react';
 import { bindActionCreators } from 'redux';
 import Card from 'react-bootstrap/Card';
 import Button from 'react-bootstrap/Button';
-import { loadRockets, reserveRocket } from '../redux/rockets/rockets';
+import { loadRockets, reserveRocket, cancelRocketReservation } from '../redux/rockets/rockets';
 
 const Rockets = () => {
   const dispatch = useDispatch();
   const loadRocketsAction = bindActionCreators(loadRockets, dispatch);
   const reserveRocketsAction = bindActionCreators(reserveRocket, dispatch);
+  const cancelRocketReservationAction = bindActionCreators(cancelRocketReservation, dispatch);
   const rockets = useSelector((state) => state.rockets);
 
   useEffect(() => {
@@ -34,11 +35,17 @@ const Rockets = () => {
               <p>{rocket.description}</p>
             </Card.Body>
             <Button
-              variant="primary"
-              onClick={() => reserveRocketsAction(rocket.id)}
+              variant={rocket.reserved ? 'outline-secondary' : 'primary'}
+              onClick={
+                () => {
+                  if (rocket.reserved) {
+                    cancelRocketReservationAction(rocket.id);
+                  } else reserveRocketsAction(rocket.id);
+                }
+              }
               style={{ width: '140px' }}
             >
-              Reserve Rocket
+              {rocket.reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
             </Button>
           </div>
         </Card>

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -3,6 +3,7 @@ const URL = 'https://api.spacexdata.com/v3/rockets';
 // Actions
 const LOAD = 'spaceships/rockets/LOAD';
 const RESERVE_ROCKET = 'spaceships/rockets/RESERVE_ROCKET';
+const CANCEL_ROCKET_RESERVATION = 'spaceships/rockets/CANCEL_ROCKET_RESERVATION';
 
 // Reducer
 export default (state = [], action) => {
@@ -13,6 +14,13 @@ export default (state = [], action) => {
       const newState = state.map((rocket) => {
         if (rocket.id !== action.id) return rocket;
         return { ...rocket, reserved: true };
+      });
+      return newState;
+    }
+    case (CANCEL_ROCKET_RESERVATION): {
+      const newState = state.map((rocket) => {
+        if (rocket.id !== action.id) return rocket;
+        return { ...rocket, reserved: false };
       });
       return newState;
     }
@@ -35,5 +43,10 @@ export const loadRockets = () => async (dispatch) => {
 
 export const reserveRocket = (id) => ({
   type: RESERVE_ROCKET,
+  id,
+});
+
+export const cancelRocketReservation = (id) => ({
+  type: CANCEL_ROCKET_RESERVATION,
   id,
 });


### PR DESCRIPTION
In this milestone, the following requirements have been met:
- [x] Follow the same logic as with the `Reserve Rocket` - but you need to set the `reserved` key to `false`. 
- [x] Dispatch these actions upon click on the corresponding buttons.